### PR TITLE
Fix for crash when using this component and not setting any initial text

### DIFF
--- a/RichTextEditor/Source/RichTextEditor.m
+++ b/RichTextEditor/Source/RichTextEditor.m
@@ -55,8 +55,6 @@
 	
 	self.typingAttributesInProgress = NO;
 	self.defaultIndentationSize = 15;
-	
-	[self updateToolbarState];
 }
 
 - (void)setSelectedTextRange:(UITextRange *)selectedTextRange


### PR DESCRIPTION
If you remove the text from the storyboard that is pre-populating the RichTextEditor, when you tap the RichTextEditor, the app will crash. The reason behind this, is that initially the text views attributed string has no attributes, and consequently the typing attributes has nothing in it, which crashes upon startup, and the initial tap in the text editor.

The fix is to wait until the setSelectedTextRange is called when the user first taps in the RichTextEditor to call updateToolbarState.
