### PR TITLE
Fix for left aligning not working after changing the alignment.

### DIFF
--- a/RichTextEditor/Source/RichTextEditor.m
+++ b/RichTextEditor/Source/RichTextEditor.m
@@ -143,7 +143,11 @@
 {
 	#warning reuse this logic in richTextEditorToolbarDidSelectTextAlignment & richTextEditorToolbarDidSelectParagraphIndentation
 	
-	NSArray *rangeOfParagraphsInSelectedText = [self.attributedText rangeOfParagraphsFromTextRange:self.selectedRange];
+    //rangeOfParagraphsFromTextRange crashes if there is no text
+	NSArray *rangeOfParagraphsInSelectedText = nil;
+    if ([self hasText]) {
+        rangeOfParagraphsInSelectedText = [self.attributedText rangeOfParagraphsFromTextRange:self.selectedRange];
+    }
 	NSInteger startRange = 0;
 	NSInteger endRange = 0;
 	
@@ -187,8 +191,12 @@
 - (void)richTextEditorToolbarDidSelectTextAlignment:(NSTextAlignment)textAlignment
 {
 	#warning reuse this logic in richTextEditorToolbarDidSelectTextAlignment & richTextEditorToolbarDidSelectParagraphIndentation
-	
-	NSArray *rangeOfParagraphsInSelectedText = [self.attributedText rangeOfParagraphsFromTextRange:self.selectedRange];
+
+    //rangeOfParagraphsFromTextRange crashes if there is no text
+	NSArray *rangeOfParagraphsInSelectedText = nil;
+    if ([self hasText]) {
+        rangeOfParagraphsInSelectedText = [self.attributedText rangeOfParagraphsFromTextRange:self.selectedRange];
+    }
 	NSInteger startRange = 0;
 	NSInteger endRange = 0;
 	


### PR DESCRIPTION
If you are changing the alignment for the entire text, sometimes the left alignment won't work again. With the lorem ipsum text in the demo, tap in the center of the screen. Change center align, and then back to left align. The left alignment doesn't work.

Also, I found out that if there is text in the editor already, then we do need to call updateToolbarState.
