### PR TITLE
Fix memory bug that was releasing font before using it

### DIFF
--- a/RichTextEditor/Source/Categories/UIFont+RichTextEditor.m
+++ b/RichTextEditor/Source/Categories/UIFont+RichTextEditor.m
@@ -64,8 +64,9 @@
 	if (newFontRef)
 	{
 		NSString *fontNameKey = (__bridge NSString *)(CTFontCopyName(newFontRef, kCTFontPostScriptNameKey));
+		CGFloat size = CTFontGetSize(newFontRef);
 		CFRelease(newFontRef);
-		return [UIFont fontWithName:fontNameKey size:CTFontGetSize(newFontRef)];
+		return [UIFont fontWithName:fontNameKey size:size];
 	}
 	
 	return nil;


### PR DESCRIPTION
Without this fix, the sample app crashes when changing the font (and perhaps when changing some other settings as well?)
